### PR TITLE
ignore non-strings on validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
         dateRegExp = /^[0-9]{4,}-[0-9]{2}-[0-9]{2}$/;
 
     exports.date = function (value) {
-        if (dateRegExp.test(value) && moment(value, 'YYYY-MM-DD').isValid()) {
+        if (typeof value !== 'string' || (dateRegExp.test(value) && moment(value, 'YYYY-MM-DD').isValid())) {
             return null;
         }
 
@@ -18,8 +18,9 @@
 
     exports['date-time'] = function (value) {
         if (
+            typeof value !== 'string' || (
             dateTimeRegExp.test(value) &&
-            moment(value).isValid()
+            moment(value).isValid())
         ) {
             return null;
         }
@@ -28,7 +29,7 @@
     };
 
     exports.email = function (value) {
-        if (validator.isEmail(value)) {
+        if (typeof value !== 'string' || validator.isEmail(value)) {
             return null;
         }
 
@@ -36,7 +37,7 @@
     };
 
     exports.uri = function (value) {
-        if (uriRegExp.test(value)) {
+        if (typeof value !== 'string' || uriRegExp.test(value)) {
             return null;
         }
 
@@ -44,7 +45,7 @@
     };
 
     exports.url = function (value) {
-        if (validator.isURL(value)) {
+        if (typeof value !== 'string' || validator.isURL(value)) {
             return null;
         }
 
@@ -60,6 +61,6 @@
     };
 
     exports.duration = function (value) {
-        return durationRegExp.test(value) ? null : 'ISO 8601 duration is expected';
+        return (typeof value !== 'string' || durationRegExp.test(value)) ? null : 'ISO 8601 duration is expected';
     };
 }());

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -13,6 +13,10 @@ describe('tv4-formats', function () {
             assert.strictEqual(formats.date('2014-02-11'), null);
         });
 
+        it('returns no error when the value is not a string', function () {
+            assert.strictEqual(formats.date(null), null);
+        });
+
         it('complains about 30th of February, mentioning the expected format', function () {
             assert(/YYYY-MM-DD/.test(formats.date('2014-02-30')));
         });
@@ -43,6 +47,10 @@ describe('tv4-formats', function () {
             assert.strictEqual(formats['date-time']('2014-02-11T15:19:59.000+00:00'), null);
         });
 
+        it('returns no error when the value is not a string', function () {
+            assert.strictEqual(formats['date-time'](null), null);
+        });
+
         it('it complains on garbage', function () {
             assert(formats['date-time']('jsdfhdfsb hjsbdfhbdhbbfd hjsdb').length > 0);
         });
@@ -67,6 +75,10 @@ describe('tv4-formats', function () {
 
         it('validates negatively', function () {
             assert(formats.email('#not_an_email').length > 0);
+        });
+
+        it('returns no error when the value is not a string', function () {
+            assert.strictEqual(formats.email(null), null);
         });
     });
 
@@ -95,6 +107,10 @@ describe('tv4-formats', function () {
             assert.strictEqual(formats.uri('../export.xml'), null);
         });
 
+        it('returns no error when the value is not a string', function () {
+            assert.strictEqual(formats.uri(null), null);
+        });
+
         it('validates negatively', function () {
             assert(formats.uri('+41 43 000 00 00 Grüezi').length > 0);
         });
@@ -111,6 +127,10 @@ describe('tv4-formats', function () {
 
         it('validates negatively', function () {
             assert(formats.url('#clearly# :not: a URL').length > 0);
+        });
+
+        it('returns no error when the value is not a string', function () {
+            assert.strictEqual(formats.url(null), null);
         });
     });
 
@@ -156,6 +176,8 @@ describe('tv4-formats', function () {
             });
         });
 
-
+        it('returns no error when the value is not a string', function () {
+            assert.strictEqual(formats.duration(null), null);
+        });
     });
 });


### PR DESCRIPTION
Format validators are expected to only validate if the type makes sense (i.e. is a string in most cases).

Example:
```json
{
  "type": [
    "string",
    "null"
  ],
  "format": "email"
}
````

is expected to allow `null` as well as a string in email format. The current implementation relies on validator.js and RegExes for validation and applies them to the value no matter what type it is. This leads to a validation error if the value of the above schema is `null` which is actually allowed.

This pull request fixes this by returning `null` if the value is not a string on all string-based formats (all but credit card, which could theoretically be a number).
Tests included.