### PR TITLE
Add Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,37 @@
+{
+  "name": "tv4-formats",
+  "version": "1.0.0.1",
+  "description": "Common JSON Schema string format constraints in the form of tv4 validator callbacks",
+  "main": "index.js",
+  "dependencies": {
+    "moment": "2.5.1",
+    "validator": "3.27.0"
+  },
+  "devDependencies": {
+    "jscs": "^1.10.0",
+    "jshint": "^2.5.11",
+    "mocha": "^2.1.0"
+  },
+  "moduleType": [
+    "node"
+  ],
+  "keywords": [
+    "json",
+    "schema",
+    "validator",
+    "tv4",
+    "format"
+  ],
+  "authors": [
+    "Ivan Krechetov <ikr@ikr.su>"
+  ],
+  "homepage": "https://github.com/ikr/tv4-formats",
+  "license": "MIT",
+  "ignore": [
+    "node_modules",
+    "bower_components",
+    "tests",
+    "README.md"
+  ],
+  "private": true
+}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "moment": ">= 2.5.1",
-    "validator": ">= 3.27.0"
+    "validator-js": ">= 3.27.0"
   },
   "devDependencies": {
     "jscs": "^1.10.0",

--- a/bower.json
+++ b/bower.json
@@ -4,8 +4,8 @@
   "description": "Common JSON Schema string format constraints in the form of tv4 validator callbacks",
   "main": "index.js",
   "dependencies": {
-    "moment": "2.5.1",
-    "validator": "3.27.0"
+    "moment": ">= 2.5.1",
+    "validator": ">= 3.27.0"
   },
   "devDependencies": {
     "jscs": "^1.10.0",

--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
 (function () {
     'use strict';
 
-    var validator;
+    var validator,
+        moment = require('moment'),
+        dateTimeRegExp = require('./src/dateTimeRegExp'),
+        uriRegExp = require('./src/uriRegExp'),
+        durationRegExp = require('./src/durationRegExp'),
+        dateRegExp = /^[0-9]{4,}-[0-9]{2}-[0-9]{2}$/;
+
     try {
         /* NPM module name */
         validator = require('validator');
@@ -10,11 +16,6 @@
         /* Bower module name */
         validator = require('validator-js');
     }
-    var moment = require('moment'),
-        dateTimeRegExp = require('./src/dateTimeRegExp'),
-        uriRegExp = require('./src/uriRegExp'),
-        durationRegExp = require('./src/durationRegExp'),
-        dateRegExp = /^[0-9]{4,}-[0-9]{2}-[0-9]{2}$/;
 
     exports.date = function (value) {
         if (dateRegExp.test(value) && moment(value, 'YYYY-MM-DD').isValid()) {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,16 @@
 (function () {
     'use strict';
 
+    var validator;
+    try {
+        /* NPM module name */
+        validator = require('validator');
+    }
+    catch (e) {
+        /* Bower module name */
+        validator = require('validator-js');
+    }
     var moment = require('moment'),
-        validator = require('validator'),
         dateTimeRegExp = require('./src/dateTimeRegExp'),
         uriRegExp = require('./src/uriRegExp'),
         durationRegExp = require('./src/durationRegExp'),


### PR DESCRIPTION
The module currently won't work as a bower module, because the *validator* module dependency points to another module in bower than in npm. The bower module name for the validation module is `validator-js` instead of just `validator`. To support both we first try to `require("validator-js")` and then fallback to `require("validator")`. A proper `bower.json` is also added.