### PR TITLE
Hide validator-js from browserify and webpack.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
     }
     catch (e) {
         /* Bower module name */
-        validator = require('validator-js');
+        validator = require('validator-js' + '');
     }
 
     exports.date = function (value) {


### PR DESCRIPTION
When a simple string is provided to `require` WebPack and browserify will attempt to find it to add it to the bundle.
Since the `npm` name is different it will not be found in the local `node_modules`.
By making the string a simple expression ( by adding a `+''` ) browserify and WebPack will ignore this require.