### PR TITLE
add require_tld: false optioin to validator.isURL to allow localhost url

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@
     };
 
     exports.url = function (value) {
-        if (validator.isURL(value)) {
+        if (validator.isURL(value, { 'require_tld': false })) {
             return null;
         }
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -125,6 +125,10 @@ describe('tv4-formats', function () {
             assert.strictEqual(formats.url('https://ikr.su/'), null);
         });
 
+        it('validates positively', function () {
+            assert.strictEqual(formats.url('http://localhost:3000/'), null);
+        });
+
         it('validates negatively', function () {
             assert(formats.url('#clearly# :not: a URL').length > 0);
         });


### PR DESCRIPTION
Hey ikr,

I just made this PR to allow localhost urls for url format. Validator.js changed the behavior of isURL with 8.0.0. release.

Take care,

Simon