### PR TITLE
require tld in url for non localhost domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,9 @@
     };
 
     exports.url = function (value) {
-        if (validator.isURL(value, { 'require_tld': false })) {
+        var tldRequired = value.indexOf('localhost') === -1;
+
+        if (validator.isURL(value, { 'require_tld': tldRequired })) {
             return null;
         }
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -121,15 +121,19 @@ describe('tv4-formats', function () {
             assert.strictEqual(typeof formats.url, 'function');
         });
 
-        it('validates positively', function () {
+        it('validates positively 1', function () {
             assert.strictEqual(formats.url('https://ikr.su/'), null);
         });
 
-        it('validates positively', function () {
+        it('validates positively 2', function () {
             assert.strictEqual(formats.url('http://localhost:3000/'), null);
         });
 
-        it('validates negatively', function () {
+        it('validates negatively 1', function () {
+            assert(formats.url('http://asdf:3000/').length > 0);
+        });
+
+        it('validates negatively 2', function () {
             assert(formats.url('#clearly# :not: a URL').length > 0);
         });
     });


### PR DESCRIPTION
Hey Ivan,

it's me again. ;-)

I just noticed in my own package [json-schema-remote](https://www.npmjs.com/package/json-schema-remote) that the require_tld flag does not work well in some cases. For localhost urls validator should not require tlds but for all the others it should.

This PR adds this by testing for the presence of `localhost` in the url. I think this will handle most false-positives.

Take care,
Simon