### PR TITLE
switch to node 8 in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - '4'
   - '6'
-  - '7'
+  - '8'


### PR DESCRIPTION
Hey Ivan,

this is a small one. Switched node 7 to node 8 in travis CI since it can be considered current/LTS.

Take care,
Simon